### PR TITLE
Match htsat patch size in checkpoint

### DIFF
--- a/configs/model/audio_encoder/htsat.yaml
+++ b/configs/model/audio_encoder/htsat.yaml
@@ -7,7 +7,7 @@ encoder:
   mel_bins: 64
   spec_window_size: 1024
   hop_size: 480
-  patch_size: 16
+  patch_size: 4
   embed_dim: 128
   depths:
     - 2


### PR DESCRIPTION
currently ya get dim mismatch on loading the [htsat checkpoint](https://huggingface.co/Pliploop/my-checkpoints/tree/main/pretrained)...updating to `patch_size` of 4 fixes it. This is same val I had to use for other public HTSAT checkpoints too.